### PR TITLE
don't error to stderr if ag not found

### DIFF
--- a/rc/search-doc.kak
+++ b/rc/search-doc.kak
@@ -1,7 +1,7 @@
 provide-module search-doc %~
 
 declare-option str search_doc_command %sh(
-    if which "ag" >/dev/null; then
+    if command -v "ag" >/dev/null 2>/dev/null; then
         printf "%s" "ag --only-matching --recurse --all-text"
     else
         printf "%s" "grep -RHnPo"


### PR DESCRIPTION
If `ag` not found *debug* buffer gets populated with error messages. This PR fixes this.
I believe `command -v` is more preferred way, as it's shell builtin.
https://discuss.kakoune.com/t/best-practices-for-finding-executable/501